### PR TITLE
Initial write up of restore / desync troubles.

### DIFF
--- a/.github/workflows/xml2rfc.yml
+++ b/.github/workflows/xml2rfc.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: cache xml2rfc cache
         id: xml2rfc-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: xml2rfc-cache
           path: .cache-xml2rfc
@@ -41,7 +41,7 @@ jobs:
             xml2rfc -p output --text --html output/draft-ietf-sidrops-publication-server-bcp-01.xml
 
       - name: Archive output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: xml2rfc-output
           path: output/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 draft-ietf-sidrops-publication-server-bcp-*.xml
 draft-ietf-sidrops-publication-server-bcp-*.html
 draft-ietf-sidrops-publication-server-bcp-*.txt
+draft-ietf-sidrops-publication-server-bcp-*.pdf
 .DS_Store

--- a/draft-ietf-sidrops-publication-server-bcp-01.md
+++ b/draft-ietf-sidrops-publication-server-bcp-01.md
@@ -175,6 +175,7 @@ between 15 and 95 minutes for the repositories that were the subject of this
 study. As seen in this study, the delay between signing and publication can be a
 major contributant to long propogation times.
 
+The potential unavailability of a Publication Server adds to this propagation delay.
 Publication Servers SHOULD therefore aim for high availability of the [@!RFC8181]
 publication protocol.
 

--- a/draft-ietf-sidrops-publication-server-bcp-01.md
+++ b/draft-ietf-sidrops-publication-server-bcp-01.md
@@ -219,12 +219,14 @@ Server's RRDP repository to verify that the objects it expects are updated in
 a timely manner. Because this would rely on conditional retrieval of the RRDP
 Notification file the CA MAY perform this verification every minute.
 
-If the expected files are not found to be published within a reasonable time
-(let's say 5 minutes?), or if the CA recognises that there is a regression in
-the files seen at the repository (e.g. previous manifest number), then it
-SHOULD perform a Full Synchronisation as described above in section 4.4.1 of
-this document.
-
+If the expected files are not found to be published within 5 minutes, or a
+regression is observed, then the CA SHOULD send the Publiczation Server an
+[@!RFC8181] list query. In case the list reply differs from the expected set
+of files, then the Publication Server and CA have become desynchronized and the
+CA SHOULD send an [@!RFC8181] multi-element publication query to update its
+content. If the list reply matches the expected set of files, but they are
+consistently not seen in the RRDP repository then this points at an operational
+issue at the Publication Server.
 
 # RRDP Repository
 

--- a/draft-ietf-sidrops-publication-server-bcp-01.md
+++ b/draft-ietf-sidrops-publication-server-bcp-01.md
@@ -106,8 +106,8 @@ that their Publication Server ([@!RFC8181]) is available when there is a need to
 update RPKI objects such as ROAs.
 
 However, availability issues with such repositories are frequent and negatively
-impact RP software. Therefore, it is strongly RECOMMENDED that organistions use
-a publication service provided by their RIR, NIR or other parent as much as
+impact RPs. Therefore, it is strongly RECOMMENDED that organistions use a
+publication service provided by their RIR, NIR or other parent as much as
 possible.
 
 Furthermore, it is RECOMMENDED that CAs that act as a parent and which operate

--- a/draft-ietf-sidrops-publication-server-bcp-01.md
+++ b/draft-ietf-sidrops-publication-server-bcp-01.md
@@ -162,11 +162,23 @@ of the root cause for disruption in the Publication Server that effectively is
 part of their infrastructure, and helps publishers avoid - if possible -
 changes in published RPKI objects that are needed during these windows.
 
-## Availability and Data Loss
+## Availability
 
-The Publication Server MUST ensure high availability of the [@!RFC8181]
-publication protocol. If this protocol is not available then this will prevent
-publishers from updating their ROAs and renewing their manifests and CRLs.
+Short outages of an [@!RFC8181] publication server will not affect RPs as long
+as the corresponding RRDP and RSYNC repositories remain available. However, such
+outages prevent publishers from updating their ROAs and renewing their manifests
+and CRLs in a timely manner. 
+
+The propagation time between CA ROA generation and the ultimate use of resulting
+VRPs in routers is described in table 2 of [@rpki-time-in-flight] and varies
+between 15 and 95 minutes for the repositories that were the subject of this
+study. As seen in this study, the delay between signing and publication can be a
+major contributant to long propogation times.
+
+Publication Servers SHOULD therefore aim for high availability of the [@!RFC8181]
+publication protocol.
+
+## Data Loss
 
 Publication Servers MUST aim to minimise data loss in case of severe server
 outages. If a server restore is needed and a content regression has occured due
@@ -177,13 +189,13 @@ have changes that need to be published. As a result they may not be aware if the
 server performed a restore and their content regressed to an earlier state. This
 could result in two problems:
 
- - The ROAs may not reflect what the publisher intended
+ - The ROAs may not reflect what the publisher intended.
  - The publisher may not renew their manifest or CRL in time, because they
    assume that their current manifest and CRL have not yet expired or become
-   stale
-   - Changes to publishers may not have been persisted. Newly registered 
-     publishers may not be present, recently removed publishers may still
-     be present.
+   stale.
+ - Changes to publishers may not have been persisted. Newly registered 
+   publishers may not be present, recently removed publishers may still
+   be present.
 
 Therefore, the Publication Server SHOULD notify publishing CAs about this issue
 if it occurs, so that a full manually triggered resynchronisation can then be
@@ -574,5 +586,22 @@ document.
             <organization>APNIC</organization>
         </author>
         <date year='2018'/>
+    </front>
+</reference>
+
+<reference anchor='rpki-time-in-flight' target='https://www.iijlab.net/en/members/romain/pdf/romain_pam23.pdf'>
+    <front>
+        <title>RPKI Time-of-Flight: Tracking Delays in the Management, Control, and Data Planes</title>
+        <author fullname='Romain Fontugne'>
+        </author>
+        <author fullname='Amreesh Phokeer'>
+        </author>
+        <author fullname='Cristel Pelsser'>
+        </author>
+        <author fullname='Kevin Vermeulen'>
+        </author>
+        <author fullname='Randy Bush'>
+        </author>
+        <date year='2022'/>
     </front>
 </reference>

--- a/draft-ietf-sidrops-publication-server-bcp-01.md
+++ b/draft-ietf-sidrops-publication-server-bcp-01.md
@@ -203,8 +203,6 @@ initiated by CAs.
 
 ## Publisher Repository Synchronisation
 
-### Full Synchronisation
-
 It is RECOMMENDED that publishing CAs always perform a list query as described
 in section 2.3 of [@!RFC8181] before sending all their changes using multiple
 PDUs as described in section 2.2 of [@!RFC8181]. This way any desynchronisation
@@ -218,30 +216,6 @@ i.e. 1000s, of publishers this operation could become costly, and unfortunately
 the [@!RFC8181] protocol has no clean support for rate limiting. Therefore,
 publishers SHOULD NOT perform this resynchronisation more frequently than once
 every 10 minutes.
-
-### Monitoring Repository Content
-
-It should be noted that the [@!RFC8181] list reply returned by a Publication
-Server can differ from the actual set of objects that are published. This is
-because the Publication Server needs time between accepting updates from one
-of their publishers and updating the content of the public repositories, or it
-may be because the Publication Server chooses to limit the number of deltas that
-it publishes to a maximum of 1 delta per minute as described in section 5.4 of
-this document.
-
-In either case, the publishing CA can monitor the content of their Publication
-Server's RRDP repository to verify that the objects it expects are updated in
-a timely manner. Because this would rely on conditional retrieval of the RRDP
-Notification file the CA MAY perform this verification every minute.
-
-If the expected files are not found to be published within 5 minutes, or a
-regression is observed, then the CA SHOULD send the Publiczation Server an
-[@!RFC8181] list query. In case the list reply differs from the expected set
-of files, then the Publication Server and CA have become desynchronized and the
-CA SHOULD send an [@!RFC8181] multi-element publication query to update its
-content. If the list reply matches the expected set of files, but they are
-consistently not seen in the RRDP repository then this points at an operational
-issue at the Publication Server.
 
 # RRDP Repository
 

--- a/draft-ietf-sidrops-publication-server-bcp-01.md
+++ b/draft-ietf-sidrops-publication-server-bcp-01.md
@@ -181,6 +181,9 @@ could result in two problems:
  - The publisher may not renew their manifest or CRL in time, because they
    assume that their current manifest and CRL have not yet expired or become
    stale
+   - Changes to publishers may not have been persisted. Newly registered 
+     publishers may not be present, recently removed publishers may still
+     be present.
 
 Therefore, the Publication Server SHOULD notify publishing CAs about this issue
 if it occurs, so that a full manually triggered resynchronisation can then be

--- a/draft-ietf-sidrops-publication-server-bcp-01.md
+++ b/draft-ietf-sidrops-publication-server-bcp-01.md
@@ -92,7 +92,29 @@ Protocol. The Publication Server generates the content for the public-facing
 RRDP and Rsync Repositories. It is strongly RECOMMENDED that these functions
 are separated from serving the repository content.
 
-## Availability
+## Self Hosted Publication Server
+
+Some organisations that use a self-hosted CA, rather than for example a hosted
+CA as service provided by their RIR or NIR, also run a self-hosted Publication
+Server for their CA. In this case, the organisation is responsible for ensuring
+the availability of the RRDP and rsync content as described in section 5 and 6
+of this document.
+
+Because RPs use cached data, short outages don't need to cause immediate issues
+if these organisations fix their repositories before objects expire and ensure
+that their Publication Server ([@!RFC8181]) is available when there is a need to
+update RPKI objects such as ROAs.
+
+However, availability issues with such repositories are frequent and negatively
+impact RP software. Therefore, it is strongly RECOMMENDED that organistions use
+a publication service provided by their RIR, NIR or other parent as much as
+possible.
+
+Furthermore, it is RECOMMENDED that CAs that act as a parent and which operate
+a Publication Server offer publication as a service to CAs under their CA
+hierarchy, i.e. direct child CAs, grandchildren, great grandchildren, etc.
+
+## Publication Server as a Service
 
 The Publication Server and repository content have different demands on their
 availability and reachability. While the repository content MUST be highly
@@ -157,20 +179,37 @@ network, unexpected fallback to snapshot). Besides increasing the capacity, we
 will discuss several other measures to reduce bandwidth demands. Which measures
 are most effective is situational.
 
-## Content Delivery Network
+## Content Availability
 
-If possible, it is strongly RECOMMENDED that a Content Delivery Network is used
-to serve the RRDP content. Care MUST BE taken to ensure that the Notification
-File is not cached for longer than 1 minute unless the back-end RRDP Repository
-is unavailable, in which case it is RECOMMENDED that stale files are served.
+Publication Servers MUST ensure the high availability of their RRDP repository
+content.
 
-When using a CDN, it will likely cache 404s for files not found on the back-end
-server. Because of this, the Publication Server SHOULD use randomized,
-unpredictable paths for Snapshot and Delta Files to avoid the CDN caching such
-404s for future updates.
+If possible, it is strongly RECOMMENDED that a Content Delivery Network (CDN) is
+used to serve the RRDP content. Care MUST be taken to ensure that the
+Notification File is not cached for longer than 1 minute unless the back-end
+RRDP Repository is unavailable, in which case it is RECOMMENDED that stale files
+are served.
 
-Alternatively, the Publication Server can delay writing the notification file
-for this duration or clear the CDN cache for any new files it publishes.
+A CDN will likely cache 404s for files not found on the back-end server. Because
+of this, the Publication Server SHOULD use randomized, unpredictable paths for
+Snapshot and Delta Files to avoid the CDN caching such 404s for future updates.
+Alternatively, the Publication Server can clear the CDN cache for any new files
+it publishes.
+
+Note that some organisations that run a Publication Server may be able to attain
+a similar level of availability themselves without the use of a third-party CDN.
+This document makes no specific recommendations on achieving this, as this is
+highly dependent on local circumstances and operational preferences.
+
+Also note that small repositories that serve a single CA, and which serve a
+small amount of data that does not change frequently, may attain high
+availability using a modest setup. Short downtime would not lead to immediate
+issues for the CA, provided that the issues get resolved before their manifest
+and CRL expire. This may be acceptable to the CA operator, however, because this
+can negatively impact RPs it is RECOMMENDED that these CAs use a Publication
+Server that is provided as a service, e.g. by their RIR or NIR, instead if they
+can.
+
 
 ## Limit Notification File Size
 
@@ -368,28 +407,6 @@ The number of rsyncd servers needed depends on the number of RPs, their refresh
 rate, and the "max connections" used. These values are subject to change over
 time, so we cannot give clear recommendations here except to restate that we
 RECOMMEND load-testing rsync and re-evaluating these parameters over time.
-
-# Single CA Repositories
-
-Some delegated CAs in the RPKI use their own dedicated Repository.
-
-Operating a small repository is much easier than operating a large one.
-There may not be a need to use a CDN for RRDP because the notification,
-snapshot and delta are relatively small. Also, the performance issues of
-rscynd for recursive fetches are far less of a problem for small and flat
-repositories.
-
-Because RPs will use cached data, short outages don't need to cause
-immediate issues if CAs fix their Repository before objects expire and
-ensure that their Publication Server ([@!RFC8181]) is available when there
-is a need to update RPKI objects such as ROAs.
-
-However, availability issues with such repositories are frequent, which
-can negatively impact Relying Party software. Therefore, it is strongly
-RECOMMENDED that CAs use a publication service provided by their RIR,
-NIR or other parent as much as possible. And it is RECOMMENDED that CAs
-that act as a parent make a Publication Service available to their
-children.
 
 
 # Acknowledgments

--- a/draft-ietf-sidrops-publication-server-bcp-01.md
+++ b/draft-ietf-sidrops-publication-server-bcp-01.md
@@ -206,9 +206,10 @@ initiated by CAs.
 
 It is RECOMMENDED that publishing CAs always perform a list query as described
 in section 2.3 of [@!RFC8181] before sending all their changes using multiple
-PDUs as described in section 2.2 of [@!RFC8181]. This way any desynchronisation
-issue can be resolved at least as soon as the publisher is aware of updates that
-it needs to publish.
+PDUs in a single multi-element query message as described in section 2.2 and
+section 3.7.1 of [@!RFC8181]. This way any desynchronisation issue can be
+resolved at least as soon as the publisher is aware of updates that it needs to
+publish.
 
 In addition to this the publishing CA MAY perform regular planned
 synchronisation events where it issues an [@!RFC8181] list query even if it has

--- a/draft-ietf-sidrops-publication-server-bcp-01.md
+++ b/draft-ietf-sidrops-publication-server-bcp-01.md
@@ -217,7 +217,7 @@ no new content to publish. For Publication Server that serve a large number,
 i.e. 1000s, of publishers this operation could become costly, and unfortunately
 the [@!RFC8181] protocol has no clean support for rate limiting. Therefore,
 publishers SHOULD NOT perform this resynchronisation more frequently than once
-every 10 minutes.
+every 10 minutes unless otherwise agreed with the publication server.
 
 # RRDP Repository
 

--- a/draft-ietf-sidrops-publication-server-bcp-01.md
+++ b/draft-ietf-sidrops-publication-server-bcp-01.md
@@ -198,9 +198,9 @@ it needs to publish.
 
 In addition to this the publishing CA MAY perform regular planned
 synchronisation events where it issues an [@!RFC8181] list query even if it has
-no new content to publish. Because this interaction requires that the
-Publication Server signs an [@!RFC8181] list reply, this operation can be costly
-for Publication Servers that serve a large number of publishers. Therefore,
+no new content to publish. For Publication Server that serve a large number,
+i.e. 1000s, of publishers this operation could become costly, and unfortunately
+the [@!RFC8181] protocol has no clean support for rate limiting. Therefore,
 publishers SHOULD NOT perform this resynchronisation more frequently than once
 every 10 minutes.
 

--- a/mktext_docker.sh
+++ b/mktext_docker.sh
@@ -14,4 +14,4 @@ docker run --rm \
     -v $HOME/.cache/xml2rfc:/var/cache/xml2rfc \
     -w /rfc \
     paulej/rfctools \
-    xml2rfc --text --html $DRAFT.xml
+    xml2rfc --text --html --pdf $DRAFT.xml


### PR DESCRIPTION
Needs more thought...

- how normative can we / should we be wrt publishing CAs?
- we should probably also say that the publication server MUST monitor their own RRDP repository against hash regressions as per https://datatracker.ietf.org/doc/draft-ietf-sidrops-rrdp-desynchronization/