### PR TITLE
Fix some minor inconsistencies and typos

### DIFF
--- a/draft-ietf-sidrops-publication-server-bcp-03.md
+++ b/draft-ietf-sidrops-publication-server-bcp-03.md
@@ -113,7 +113,7 @@ the availability of the RRDP and rsync content as described in section 5 and 6
 of this document.
 
 RPs are expected to make use of cached data from a previous, successful fetch
-(Section 6 of @!RFC9286). Therefor, short outages on the server side don't need
+(Section 6 of [@!RFC9286]). Therefor, short outages on the server side don't need
 to be cause for immediate concern, provided the server operator restores access
 availability in a timely fashion (e.g. before objects expire).
 

--- a/draft-ietf-sidrops-publication-server-bcp-03.md
+++ b/draft-ietf-sidrops-publication-server-bcp-03.md
@@ -113,7 +113,7 @@ the availability of the RRDP and rsync content as described in section 5 and 6
 of this document.
 
 RPs are expected to make use of cached data from a previous, successful fetch
-(Section 6 of [@!RFC9286]). Therefor, short outages on the server side don't need
+(Section 6 of [@!RFC9286]). Therefore, short outages on the server side don't need
 to be cause for immediate concern, provided the server operator restores access
 availability in a timely fashion (e.g. before objects expire).
 
@@ -227,7 +227,7 @@ synchronisation events where it issues an [@!RFC8181] list query even if it has
 no new content to publish. For Publication Server that serve a large number of
 CAs (e.g. 1000s) this operation could become costly from a resource consumption
 perspective. Unfortunately the [@!RFC8181] protocol has no proper support for
-rate limiting. Therefor, publishers SHOULD NOT perform this resynchronisation
+rate limiting. Therefore, publishers SHOULD NOT perform this resynchronisation
 more frequently than once every 10 minutes unless otherwise agreed with the
 publication server.
 

--- a/draft-ietf-sidrops-publication-server-bcp-03.md
+++ b/draft-ietf-sidrops-publication-server-bcp-03.md
@@ -161,7 +161,7 @@ access to known source IP addresses or apply rate limits.
 If the Publication Server is unavailable for some reason, this will prevent
 Publishers from making updated RPKI objects available. The most immediate impact
 of this is that the publisher cannot distribute new issuances or revocations of
-ROAs, ASPAs or BGPSec Router Certificates for the duration of this outage. Thus,
+ROAs, ASPAs or BGPsec Router Certificates for the duration of this outage. Thus,
 in effect, it cannot signal changes in its routing operations. If the outage
 persists for an extended period, then RPKI Manifests, CRLs, and Signed Objects
 might became stale, hampering for example BGP Origin Validation ([@!RFC6811].
@@ -480,7 +480,7 @@ when written to disk. These heuristics assume that a CA is compliant with
   - For CRLs, use the value of thisUpdate.
   - For RPKI Signed Objects, use the CMS signing-time (see
     ([@!I-D.spaghetti-sidrops-cms-signing-time]))
-  - For CA and BGPSec Router Certificates, use the value of notBefore
+  - For CA and BGPsec Router Certificates, use the value of notBefore
   - For directories, use any constant value.
 
 ## Load Balancing and Testing

--- a/draft-ietf-sidrops-publication-server-bcp-03.md
+++ b/draft-ietf-sidrops-publication-server-bcp-03.md
@@ -139,7 +139,7 @@ providing publication service to CA3:
  on behalf of CA3.
  
  3. CA2 may operate a publication proxy service (per e.g.
- [@rpki-publication-proxy]), which acts as the publication server for
+ [@rpki-publication-proxy]), which acts as the Publication Server for
  CA3.  This proxy would set aside part of CA2's namespace at CA1 for
  the publication of CA3's objects, adjusting and forwarding requests
  from CA3 to CA1 accordingly.
@@ -176,7 +176,7 @@ changes in published RPKI objects that are needed during these windows.
 
 ## Availability
 
-Short outages of an [@!RFC8181] publication server will not affect RPs as long
+Short outages of an [@!RFC8181] Publication Server will not affect RPs as long
 as the corresponding RRDP and RSYNC repositories remain available. However, such
 outages prevent publishers from updating their ROAs and re-issuing their manifests
 and CRLs in a timely manner. 
@@ -229,7 +229,7 @@ CAs (e.g. 1000s) this operation could become costly from a resource consumption
 perspective. Unfortunately the [@!RFC8181] protocol has no proper support for
 rate limiting. Therefore, publishers SHOULD NOT perform this resynchronisation
 more frequently than once every 10 minutes unless otherwise agreed with the
-publication server.
+Publication Server.
 
 # RRDP Server
 

--- a/draft-ietf-sidrops-publication-server-bcp-03.md
+++ b/draft-ietf-sidrops-publication-server-bcp-03.md
@@ -407,8 +407,8 @@ period. This issue is especially prominent with CDNs that use HTTP proxies
 internally when connecting to the origin while also load-balancing over
 multiple proxies. As a result, some requests may use a connection to the
 disabled server and retrieve stale content, while other connections load data
-from another server. Depending on the exact configuration – for example, nodes
-behind the LB may have different RRDP sessions – this can lead to an
+from another server. Depending on the exact configuration - for example, nodes
+behind the LB may have different RRDP sessions - this can lead to an
 inconsistent RRDP repository.
 
 Because of this issue, we RECOMMEND to (1) limit HTTP keepalive to a short

--- a/draft-ietf-sidrops-publication-server-bcp-03.md
+++ b/draft-ietf-sidrops-publication-server-bcp-03.md
@@ -164,7 +164,7 @@ of this is that the publisher cannot distribute new issuances or revocations of
 ROAs, ASPAs or BGPsec Router Certificates for the duration of this outage. Thus,
 in effect, it cannot signal changes in its routing operations. If the outage
 persists for an extended period, then RPKI Manifests, CRLs, and Signed Objects
-might became stale, hampering for example BGP Origin Validation ([@!RFC6811].
+might became stale, hampering for example BGP Origin Validation ([@!RFC6811]).
 
 For this reason, the Publication Server MUST have a high availability.
 Measuring the availability of the Publication Server in a round-trip fashion is
@@ -349,7 +349,7 @@ Publication Server SHOULD publish changes at a regular (one-minute) interval.
 The Publication Server then publishes the updates received from all Publishers
 in this interval in a single RRDP Delta File.
 
-While, the latter may not reduce the amount of data due to changed objects,
+While the latter may not reduce the amount of data due to changed objects,
 this will result in shorter notification files, and will reduce the number of
 delta files that RPs need to fetch and process.
 


### PR DESCRIPTION
Hi,

Here are some fixes for minor inconsistencies and typos which I found during a quick read. I found some more inconsistencies but I'm not sure which variation is preferred so I didn't change them:
- _delta files_ vs _Delta Files_
- _manifest_ vs _Manifest_ (section 5.7)